### PR TITLE
Fix missing teres import

### DIFF
--- a/anabot/runtime/functions.py
+++ b/anabot/runtime/functions.py
@@ -21,6 +21,7 @@ import logging
 logger = logging.getLogger('anabot')
 
 import teres
+import teres.bkr_handlers
 reporter = teres.Reporter.get_reporter()
 
 _DEFAULT_TIMEOUT = 7


### PR DESCRIPTION
The teres.bkr_handlers is used in the code, but the bkr_handlers needs to be
imported explicitely.