### PR TITLE
Look for "Warning" icon in error bar

### DIFF
--- a/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
+++ b/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
@@ -43,7 +43,7 @@ def __initialize_toggles(devices_node):
 def check_partitioning_error(app_node):
     try:
         error_bar = getnode(app_node, "info bar", tr("Error"))
-        warn_icon = getnode(error_bar, "icon", tr("Warnings"))
+        warn_icon = getnode(error_bar, "icon", tr("Warning"))
         warn_text = getsibling(warn_icon, 1, "label")
         return (False, warn_text.text)
     except TimeoutError:


### PR DESCRIPTION
Both RHEL-8 and RHEL-9 have the icon named as "Warning", not "Warnings" which
was probably used in RHEL-7 installer.