### PR TITLE
[RTT-2432] Don't mix in mandatory groups to anabot-packageset.txt

### DIFF
--- a/anabot/runtime/installation/hub/software_selection.py
+++ b/anabot/runtime/installation/hub/software_selection.py
@@ -35,11 +35,9 @@ def record_package_selection():
     if __selected_environment is None and __selected_addons is None:
         return
     reporter.log_info('Saving package selection to %s'%PACKAGE_SELECTION_STORE)
-    addons_in_env = get_comps().mandatory_groups_list(__selected_environment)
-    addons = __selected_addons + addons_in_env
     with open(PACKAGE_SELECTION_STORE, 'w') as outfile:
         outfile.write("@^" + __selected_environment + "\n")
-        for addon in addons:
+        for addon in __selected_addons:
             outfile.write("@" + addon + "\n")
 
 def random_sublist(inlist):


### PR DESCRIPTION
The purpose of anabot-packageset.txt is to record user's selection of
environment and addons.

Listing environment *and* its mandatory groups is redundant, so let's
only list environment.  This is, after all, what anaconda does when it's
constructing kickstart.  (I've checked this on RHEL-8 and RHEL-9.)

This reverts cc7a246a from 5 years ago, where mandatory group list was
added.  However, it's not completely clear why the behavior was changed
(Not even after discussion with the original author---note that this was
before RTT was using Jira for tracking the development so there is no
additional thread).  I'm going to assume this was an attempt to to match
old anaconda / yum behavior; in that case it's not relevant now.