### PR TITLE
Add preexec hook to wait for dogtail data

### DIFF
--- a/profiles/default/hooks/30-wait_for_dogtail_data-preexec.hook
+++ b/profiles/default/hooks/30-wait_for_dogtail_data-preexec.hook
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+#
+# Pre-exec hook to wait for dogtail data
+#
+# The hook is based on "probe" that will not only enable accessibility
+# framework but also check that the data can be enumerated.
+#
+# This is to deal with flakiness of the AT-SPI interface that appears on
+# machines (reportedly, more on VM's) and can cause a11y (and thus
+# dogtail) appear as functional, but then fail when trying to talk to it.
+#
+# To verify that the whole stack works, the hook uses an in-line script
+# that will try to enable accessibility functions and dump tree of objects
+# seen by dogtail.  Furthermore, the hook will try to look for anaconda
+# window using a simple dogtail query.   If all of this is successful,
+# the hook exits with zero status.
+#
+# In case dogtail is not ready, the hook will re-try after 30 seconds.
+# This repeats for 40 attempts---if it's not successful, the hook will
+# exit with non-zero status.
+#
+
+warn() {
+    #
+    # Print lines $@ to stderr
+    #
+    local self=${0##*/}
+    for line in "$@"; do
+        echo "$self:$line" >&2
+    done
+
+}
+
+mkpy() {
+    #
+    # Print Python code for dogtail probe
+    #
+    echo 'import dogtail.utils'
+    echo 'dogtail.utils.enableA11y()'
+    echo 'import dogtail.tree'
+    echo 'dogtail.tree.root.dump()'
+    echo 'application = dogtail.tree.root.child(roleName="application", name="anaconda")'
+}
+
+verify() {
+    #
+    # True if dogtail data is available
+    #
+    local output=/tmp/wait_for_dogtail_data.out
+    local output_lines
+    PYTHONPATH=/opt/bundled/dogtail \
+    DISPLAY=:1 \
+        /usr/libexec/platform-python -c "$(mkpy)" \
+        >"$output" \
+     || return 3
+    mapfile -t output_lines <"$output"
+    warn \
+        "--- begin output ---" \
+        "${output_lines[@]}" \
+        "--- end output ---"
+    test -s "$output"
+}
+
+main() {
+    local attempts=40   # max number of attempts
+    local delay=30      # delay between attempts
+    local togo          # leftover number of attempts
+    togo=$attempts
+    while true; do
+        warn "checking for dogtail data, attempt #$((attempts - togo + 1))"
+        verify && {
+            warn "...success!"
+            return 0
+        }
+        ((togo--))
+        test "$togo" -gt 0 || break
+        warn "sleeping before next attempt: $delay, remaining attempts $togo/$attempts" 
+        sleep "$delay"
+    done
+    warn "ran out of attempts, giving up"
+    exit 1
+}
+
+main "$@"


### PR DESCRIPTION
The hook is based on "probe" that will not only enable accessibility
framework but also check that the data can be enumerated.

See the embedded comment for more details.