### PR TITLE
[RTT-2978] Add workaround for startup traceback

### DIFF
--- a/etc/systemd/system/anabot.service
+++ b/etc/systemd/system/anabot.service
@@ -5,6 +5,7 @@ ConditionArchitecture=!s390
 ConditionArchitecture=!s390x
 
 [Service]
+ExecStartPre=/usr/bin/sleep 30
 ExecStart=/opt/python_launcher.sh /opt/launcher.py anaconda_installer
 Environment="ANABOT_MODULES=/opt/anabot-modules"
 Environment="ANABOT_CONF=/opt/anabot.ini"


### PR DESCRIPTION
Adding a delay between Anaconda and Anabot start should
bring a better level of certainty that Anaconda (service)
started fully (not just reportedly), including initialization
of AT-SPI D-Bus and connection to it.

With this change, Anabot should connect properly to the
existing accessibility D-Bus (via AT-SPI/dogtail) and find
the application, instead of creating its own bus instance
in parallel to the other one, which would lead to traceback
with gi.repository.GLib.GError: atspi_error or SearchError.

This is just a workaround to get rid of the momentary tracebacks,
ideally this should be solved properly on Anaconda side.