### PR TITLE
Increase timeout for software selection spoke button

### DIFF
--- a/anabot/runtime/installation/hub/software_selection.py
+++ b/anabot/runtime/installation/hub/software_selection.py
@@ -60,7 +60,9 @@ def base_handler(element, app_node, local_node):
 
     spoke_selector.click()
     try:
-        spoke_label = getnode(app_node, "label", tr("SOFTWARE SELECTION"))
+        # Wait for up to 5 minutes -- when using CDN as installation source, it can take quite
+        # a long time for group metadat download to complete
+        spoke_label = getnode(app_node, "label", tr("SOFTWARE SELECTION"), 5*60)
         local_node = getparent(spoke_label, "filler")
     except TimeoutError:
         return (False, 'Couldn\'t find software selection spoke.')


### PR DESCRIPTION
It can take quite a long time for group metadata download to
finish when CDN is used as installation source, which blocks
the software selection button for a long time, causing timeouts
with the default value (7 s).

The longest time for the button to become active I measured when experimenting with CDN registration was something less than 3 minutes. I guess 5 minutes should cover even the worst-case scenarios.

I also thought about implementing a special timeout only for CDN installation source, but in the end it seemed overcomplicated to me.