### PR TITLE
[RTT-4715] Ensure that language is entered properly

### DIFF
--- a/anabot/runtime/installation/welcome/language.py
+++ b/anabot/runtime/installation/welcome/language.py
@@ -11,6 +11,9 @@ handle_chck = make_prefixed_handle_check(_local_path)
 def language_handler(element, app_node, local_node):
     lang = get_attr(element, "value")
     gui_lang_search = getnode(local_node, node_type="text")
+    # the whole application seems to be out of focus under some unknown circumstances, so clicking
+    # into the input field first ensures that the text will be entered properly
+    gui_lang_search.click()
     gui_lang_search.typeText(lang)
     gui_lang = getnode(local_node, "table cell", lang)
     gui_lang.click()


### PR DESCRIPTION
It seems that the whole Anaconda application is not focused at first
under some circumstances. This may cause that the language is not
entered properly in the search field and subsequently make Anabot crash
when it tries to click on a language cell that is out of the visible area.

This fix ensures that the language is found and therefore the
language cell is displayed in the visible area.