### PR TITLE
Fix disk selection behaviour for systems with specialized disks

### DIFF
--- a/anabot/preprocessor/snippets/installation/hub/autopart.xml
+++ b/anabot/preprocessor/snippets/installation/hub/autopart.xml
@@ -1,4 +1,8 @@
 <partitioning>
+  <add_specialized_disk>
+    <select name="*" />
+    <done />
+  </add_specialized_disk>
   <disk name="*" action="select" />
   <mode mode="automatic" />
   <additional_space action="enable" />

--- a/anabot/runtime/installation/hub/partitioning/__init__.py
+++ b/anabot/runtime/installation/hub/partitioning/__init__.py
@@ -18,7 +18,7 @@ from anabot.runtime.actionresult import ActionResultPass as Pass, ActionResultFa
 from anabot.runtime.installation.common import done_handler
 
 # submodules
-from . import advanced, luks_dialog
+from . import advanced, luks_dialog, specialized_disks
 
 _local_path = '/installation/hub/partitioning'
 def handle_act(path, *args, **kwargs):
@@ -114,6 +114,29 @@ def disk_handler(element, app_node, local_node):
 @handle_chck('/disk')
 def disk_check(element, app_node, local_node):
     return disk_manipulate(element, app_node, local_node, True)
+
+def add_specialized_disk_manipulate(element, app_node, local_node, dryrun):
+    try:
+        add_button = getnode(local_node, "push button", tr("Add Specialized Disk"))
+    except TimeoutError:
+        return NotFound("clickable button for adding specialized / network disks")
+    if not dryrun:
+        add_button.click()
+        try:
+            tab = getnode(app_node, "page tab", tr("Searc_h", context="GUI|Installation Destination|Filter"))
+            spec_disk_panel = getparent(tab, "panel")
+        except TimeoutError:
+            return NotFound("specialized disk page tab or panel")
+        default_handler(element, app_node, spec_disk_panel)
+    return Pass()
+
+@handle_act('/add_specialized_disk')
+def add_specialized_disk_handler(element, app_node, local_node):
+    add_specialized_disk_manipulate(element, app_node, local_node, False)
+
+@handle_chck('/add_specialized_disk')
+def add_specialized_disk_check(element, app_node, local_node):
+    return add_specialized_disk_manipulate(element, app_node, local_node, True)
 
 # RHEL-7
 def mode_manipulate(element, app_node, local_node, dryrun):

--- a/anabot/runtime/installation/hub/partitioning/specialized_disks/__init__.py
+++ b/anabot/runtime/installation/hub/partitioning/specialized_disks/__init__.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+import logging
+logger = logging.getLogger('anabot')
+
+from fnmatch import fnmatchcase
+
+from anabot.runtime.decorators import handle_action, handle_check, check_action_result
+from anabot.runtime.functions import get_attr, getnode, getnodes, getsibling
+from anabot.runtime.errors import TimeoutError
+from anabot.runtime.translate import tr
+from anabot.runtime.actionresult import NotFoundResult as NotFound, ActionResultPass as Pass, ActionResultFail as Fail
+
+_local_path = '/installation/hub/partitioning/add_specialized_disk'
+def handle_act(path, *args, **kwargs):
+    return handle_action(_local_path + path, *args, **kwargs)
+
+def handle_chck(path, *args, **kwargs):
+    return handle_check(_local_path + path, *args, **kwargs)
+
+def select_manipulate(element, app_node, local_node, dryrun):
+    name = get_attr(element, "names", "*")
+    action = get_attr(element, "action", "select")
+
+    try:
+        results_label = getnode(app_node, "label", tr("Search Res_ults:", context="GUI|Installation Destination|Filter|Search"))
+        table_pane = getsibling(results_label, 1, "scroll pane")
+        disks_table = getnode(table_pane, "table")
+    except TimeoutError:
+        return NotFound("results label, table pane or disks table")
+
+    # There are no relevant cells found if there are no specialized disks:
+    try:
+        cells = getnodes(disks_table, "table cell")
+        column_count = len(getnodes(disks_table, "table column header"))
+    except TimeoutError:
+        logger.info("No cells for specialized disks found.")
+        return Pass()
+
+    # every table row has checkbox on position 0 and device name on 1
+    name_cells = [
+        c
+        for c in cells[1::column_count]
+        if fnmatchcase(c.name, name)
+    ]
+    checkbox_cells = [
+        getsibling(c, -1, "table cell")
+        for c in name_cells
+    ]
+    logger.info("Devices that match name '%s' found: '%s'" % (name, [n.name for n in name_cells]))
+    for c in checkbox_cells:
+        device_name = getsibling(c, 1).name
+        if (action == "select") != (c.checked):
+            if dryrun:
+                return Fail("Checkbox status for device '%s' doesn't match required action '%s'" % (device_name, action))
+            logger.info("Going to click on checkbox for device '%s'" % device_name)
+            c.click()
+    return Pass()
+
+@handle_act('/select')
+def select_handler(element, app_node, local_node):
+    return select_manipulate(element, app_node, local_node, False)
+
+@handle_chck('/select')
+def select_check(element, app_node, local_node):
+    return select_manipulate(element, app_node, local_node, True)
+
+@handle_act('/done')
+def done_handler(element, app_node, local_node):
+    try:
+        done_button = getnode(app_node, "push button", tr("_Done", drop_underscore=False, context="GUI|Spoke Navigation"))
+    except TimeoutError:
+        return NotFound("clickable Done button")
+    done_button.click()
+    return Pass()
+
+@handle_chck('/done')
+@check_action_result
+def done_check(element, app_node, local_node):
+    return Pass()

--- a/anabot/runtime/installation/hub/partitioning/specialized_disks/__init__.py
+++ b/anabot/runtime/installation/hub/partitioning/specialized_disks/__init__.py
@@ -10,6 +10,7 @@ from anabot.runtime.functions import get_attr, getnode, getnodes, getsibling
 from anabot.runtime.errors import TimeoutError
 from anabot.runtime.translate import tr
 from anabot.runtime.actionresult import NotFoundResult as NotFound, ActionResultPass as Pass, ActionResultFail as Fail
+from anabot.variables import set_variable
 
 _local_path = '/installation/hub/partitioning/add_specialized_disk'
 def handle_act(path, *args, **kwargs):
@@ -43,6 +44,10 @@ def select_manipulate(element, app_node, local_node, dryrun):
         for c in cells[1::column_count]
         if fnmatchcase(c.name, name)
     ]
+    # we need to know if there are any specialized disks to also select all
+    # of the regular disks by default in such a case - see RTT-4385
+    if len(name_cells):
+        set_variable('specialized_disks_present', '1')
     checkbox_cells = [
         getsibling(c, -1, "table cell")
         for c in name_cells


### PR DESCRIPTION
Previously, the partitioning was failing if the system also contained non-standard (e. g. multipath) disks included original LVM partitioning, as Anaconda requires the user to select all of such disks.