### PR TITLE
[RTT-4707] Workaround for proper lang ids for Chinese

### DIFF
--- a/anabot/runtime/translate.py
+++ b/anabot/runtime/translate.py
@@ -5,6 +5,7 @@ import six
 import gettext
 import langtable # pylint: disable=import-error
 from .comps import get_comps
+import logging
 __translate = None
 __translate_keyboard = None
 __translate_lang = None
@@ -14,6 +15,7 @@ __oscap_translate = None
 __gtk_translate = None
 __locality = None
 __locality_re = re.compile(r"(?P<lang>[^(]*) (?:\((?P<loc>[^)]*)\))?")
+logger = logging.getLogger('anabot')
 
 def active_languages():
     return __languages
@@ -21,7 +23,18 @@ def active_languages():
 def set_languages_by_name(locality):
     match = __locality_re.match(locality)
     lang = match.group("lang")
-    set_languages([langtable.languageId(locality),
+    locality_language_id = langtable.languageId(locality)
+
+    # Chinese language id is reported as zh_XXXX_YY, but for the translation we can only use zh_YY (e. g. zh_CN)
+    chinese = re.match("(zh).*(..)", locality_language_id)
+    if chinese:
+        updated_locality_language_id = "_".join(chinese.groups())
+        logger.info("Chinese was selected, using '%s' instead of '%s." %
+            (updated_locality_language_id, locality_language_id)
+        )
+        locality_language_id = updated_locality_language_id
+
+    set_languages([locality_language_id,
                    langtable.languageId(lang),
                    "en"])
 


### PR DESCRIPTION
Anabot uses langtable to get the best guess for language id based on the language/locale selection on the Welcome screen. However, for Chinese, langtable returns *zh_XXXX_YY*, which technically might be correct, but the available translations for Anaconda are *zh_YY*.

No matter if this is a bug in the translation identifiers or not, we need to have this working, so that we can test even installations in Chinese and this workaround can be reverted in the future if there's a proper fix implemented.

To give a broader background - Anaconda gets the list of available translations based on the present localization files and their content (which, in case of Chinese, results in e. g. *zh_CN.UTF-8* as logged in anaconda.log, whereas langtable returns *zh_Hans_CN* for *简体中文 (中国)*(Simplified Chinese - China) in Anabot). The Chinese translations available in /usr/share/locale are:
```
zh_CN/LC_MESSAGES/anaconda.mo
zh_HK/LC_MESSAGES/anaconda.mo
zh_TW/LC_MESSAGES/anaconda.mo
```
The workaround just checks if the selected language id is Chinese (zh_...) and in such a case removes the middle part for simplified or traditional Chinese (*Hans*/*Hant*) to just get *zh_YY* matching the available translation ids, instead of *zh_XXXX_YY* and therefore have the translation working.