### PR TITLE
Increase timeout for registration to CDN 

### DIFF
--- a/anabot/runtime/installation/hub/connect_to_redhat/__init__.py
+++ b/anabot/runtime/installation/hub/connect_to_redhat/__init__.py
@@ -324,7 +324,7 @@ registered = [
         "Registered.",
         "Registered to Satellite."
 ]
-reg_loop_delay = 5
+reg_loop_delay = 20
 
 @handle_act('/wait_until_registered')
 def wait_until_registered_handler(element, app_node, local_node):


### PR DESCRIPTION
Apparently 5 s may not be enough, let's try 20.