### PR TITLE
Fix centos_stream8 job, add command to install config-manager

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Enable EPEL and install pylint and dependencies
         run: |
+          dnf install -y 'dnf-command(config-manager)'
+          dnf install -y python3-gobject-base
           dnf config-manager --set-enabled powertools
           dnf install -y epel-release epel-next-release
           dnf install -y python3-pylint python3-libxml2 git


### PR DESCRIPTION
This is needed, because centos_stream8 job fails due to not having the config-manager installed.