### PR TITLE
Fix unhandled exception for 'btrfs' or 'raid' partitioning on RHEL

### DIFF
--- a/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
+++ b/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
@@ -96,7 +96,12 @@ def schema_manipulate(element, app_node, local_node, check):
         return (False, u"Different schema is set: %s" % schema_node.name)
     # Select new schema
     schema_node.click()
-    getnode(schema_node, "menu item", schema_name(schema)).click()
+    try:
+        getnode(schema_node, "menu item", schema_name(schema)).click()
+    except TimeoutError:
+        # If schema name is valid but not found in the dropdown menu (e.g.
+        # 'btfrs' in RHEL), getnode raises TimeoutError.
+        pass
 
 
 @handle_act('/schema')


### PR DESCRIPTION
In the custom partitioning spoke, when Anabot tries to select non-existent items 'btrfs' or 'raid', unhandled TimeoutError was raised. This is now fixed and installation continues as expected.