### PR TITLE
[RTT-5378] Update button labels on the Beta dialog

### DIFF
--- a/anabot/conditions.py
+++ b/anabot/conditions.py
@@ -51,7 +51,7 @@ def _anaconda_version():
 
     try:
         with open('/root/lorax-packages.log') as lorax_packages_log:
-            match = re.search(r'^(anaconda)-([0-9]+\.[0-9]+(\.[0-9]+)?)',
+            match = re.search(r'^(anaconda)-([0-9]+(\.[0-9]+)*)',
                               lorax_packages_log.read(),
                               re.MULTILINE)
             version = match.group(2)

--- a/anabot/runtime/installation/welcome/beta_dialog.py
+++ b/anabot/runtime/installation/welcome/beta_dialog.py
@@ -1,3 +1,4 @@
+from anabot.conditions import is_distro, is_anaconda_version_lt
 from anabot.runtime.decorators import handle_action, handle_check
 from anabot.runtime.functions import get_attr, getnode
 from anabot.runtime.translate import tr
@@ -7,15 +8,25 @@ _local_path = '/installation/welcome/beta_dialog'
 handle_act = lambda x: handle_action(_local_path + x)
 handle_chck = lambda x: handle_check(_local_path + x)
 
+def _is_button_with_dot():
+    # The terminating dots were removed from the labels on the buttons on the Beta dialog.
+    # RHEL: https://github.com/rhinstaller/anaconda/pull/4771/commits/3a28c203cccc572db498669d76e57ceb8bbd772d
+    if is_distro('rhel') and is_anaconda_version_lt('34.25.3.4'):
+        return True
+    # Fedora: https://github.com/rhinstaller/anaconda/commit/64219c599759bfec1e538fe30d4a6f6819a3c65d
+    if is_distro('fedora') and is_anaconda_version_lt('39.4'):
+        return True
+    return False
+
 @handle_act('')
 def beta_dialog_handler(element, app_node, local_node):
     dialog_action = get_attr(element, "dialog", "accept") == "accept"
     try:
         beta_dialog = getnode(app_node, "dialog", "Beta Warn")
         if dialog_action:
-            button_text = "I want to _proceed."
+            button_text = "I want to _proceed." if _is_button_with_dot() else "I want to _proceed"
         else:
-            button_text = "I want to _exit."
+            button_text = "I want to _exit." if _is_button_with_dot() else "I want to _exit"
         button_text = tr(button_text, context="GUI|Welcome|Beta Warn Dialog")
         button = getnode(beta_dialog, "push button", button_text)
         button.click()


### PR DESCRIPTION
The terminating dots on the Beta dialog buttons have been removed in RHEL-9.3 and Fedora 39.

Beaker jobs with the changes:
J:8012823 - RHEL-9.3.0-20230622.0 with old anaconda
J:8012821 - RHEL-9.3.0-20230623.45 with new anaconda (with the dots removed)
J:8012826 - RHEL-8.9.0-20230627.22 no string change in RHEL-8