### PR TITLE
Support for choosing different kernels on aarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyo
 *~
 /[Mm]akefile
+.idea/*

--- a/doc/recipe_elements/software_selection.rst
+++ b/doc/recipe_elements/software_selection.rst
@@ -23,3 +23,11 @@ Attributes:
 
 * ``id`` - environment id (as defined in comps file)
 * ``select`` (optional) - ``random`` (random environment selection)
+
+/installation/hub/software_selection/kernel_options
+===================================================
+Handles *Kernel Options* selection on the aarch64 architecture (RHEL-9 and higher).
+
+Attributes:
+
+* ``value`` - desired kernel option (so far ``4k`` or ``64k``)


### PR DESCRIPTION
This new feature allows users to choose the kernel option on aarch64. It is needed for automatic tests.