### PR TITLE
Add support for LUKS device unlock

### DIFF
--- a/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
+++ b/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
@@ -14,7 +14,7 @@ from anabot.runtime.functions import get_attr, get_attr_bool, getnode, getnode_s
 from anabot.runtime.errors import TimeoutError
 from anabot.runtime.translate import tr, gtk_tr
 from anabot.runtime.installation.common import done_handler
-from anabot.runtime.installation.hub.partitioning.advanced.common import schema_name
+from anabot.runtime.installation.hub.partitioning.advanced.common import schema_name, check_partitioning_error
 from anabot.runtime.actionresult import NotFoundResult as NotFound, ActionResultPass as Pass, ActionResultFail as Fail
 
 import anabot.runtime.installation.hub.partitioning.advanced.details
@@ -39,15 +39,6 @@ def __initialize_toggles(devices_node):
         time.sleep(0.5)
         toggle.actions['activate'].do()
     __initialized_toggles = True
-
-def check_partitioning_error(app_node):
-    try:
-        error_bar = getnode(app_node, "info bar", tr("Error"))
-        warn_icon = getnode(error_bar, "icon", tr("Warning"))
-        warn_text = getsibling(warn_icon, 1, "label")
-        return (False, warn_text.text)
-    except TimeoutError:
-        return True
 
 def main_view(func):
     @wraps(func)

--- a/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
+++ b/anabot/runtime/installation/hub/partitioning/advanced/__init__.py
@@ -299,6 +299,16 @@ def rescan_handler(element, app_node, local_node):
         return (False, "Undefined state")
     getnode(rescan_dialog, "push button", button_text).click()
 
+@handle_chck('/rescan')
+def rescan_check(element, app_node, local_node):
+    try:
+        # Anaconda returns back to the 'Installation Destination' screen after confirming
+        # a successful rescan
+        getnode(app_node, "label", tr("INSTALLATION DESTINATION"))
+    except TimeoutError:
+        return Fail()
+    return Pass()
+
 @handle_act('/rescan/push_rescan')
 def rescan_push_rescan_handler(element, app_node, local_node):
     rescan_text = tr("_Rescan Disks", context="GUI|Refresh Dialog|Rescan")
@@ -308,7 +318,11 @@ def rescan_push_rescan_handler(element, app_node, local_node):
 @handle_chck('/rescan/push_rescan')
 def rescan_push_rescan_check(element, app_node, local_node):
     # check that scan was successfull
-    pass
+    try:
+        getnode(app_node, "label", tr("Disk rescan complete."))
+    except TimeoutError:
+        return Fail()
+    return Pass()
 
 @handle_act('/autopart')
 def autopart_handler(element, app_node, local_node):

--- a/anabot/runtime/installation/hub/partitioning/advanced/common.py
+++ b/anabot/runtime/installation/hub/partitioning/advanced/common.py
@@ -1,6 +1,8 @@
 import re
 from anabot.runtime.translate import tr
 from anabot.conditions import is_distro_version
+from anabot.runtime.functions import getnode, getsibling
+from anabot.runtime.errors import TimeoutError
 
 def schema_name(schema=None):
     SCHEMAS = {
@@ -45,3 +47,12 @@ def raid_name(raid_level=None, drop_span=True):
     if raid_level is not None:
         return LEVELS[raid_level]
     return LEVELS.values()
+
+def check_partitioning_error(app_node):
+    try:
+        error_bar = getnode(app_node, "info bar", tr("Error"))
+        warn_icon = getnode(error_bar, "icon", tr("Warning"))
+        warn_text = getsibling(warn_icon, 1, "label")
+        return (False, warn_text.text)
+    except TimeoutError:
+        return True

--- a/doc/recipe_elements/advanced_partitioning.rst
+++ b/doc/recipe_elements/advanced_partitioning.rst
@@ -165,6 +165,18 @@ Attributes:
 
 * ``value``
 
+/installation/hub/partitioning/advanced/details/luks_unlock
+===========================================================
+Handles unlocking of a selected LUKS device by (optionally) entering
+a provided password in the passphrase field and clicking on Unlock button.
+
+Attributes:
+
+* ``password`` (optional) - LUKS password. If password is not specified,
+  Anabot will only click on the Unlock button, without entering any
+  password. This may be useful if the password was already entered before
+  (e. g. after a disk rescan).
+
 /installation/hub/partitioning/advanced/details/mountpoint
 ==========================================================
 *Mount Point* input field in partition/LV details.


### PR DESCRIPTION
There's a new element for LUKS devices unlocking (`/installation/hub/partitioning/advanced/details/luks_unlock`). I used the disk rescan functionality as part of testing and found out there are missing/malfunctioning handlers for it, so I decided to also fix them. Test jobs will be linked in RTT-5231.