### PR TITLE
Fix the Anabot's Beta Dialog Problem

### DIFF
--- a/anabot/runtime/installation/welcome/beta_dialog.py
+++ b/anabot/runtime/installation/welcome/beta_dialog.py
@@ -22,7 +22,7 @@ def _is_button_with_dot():
 def beta_dialog_handler(element, app_node, local_node):
     dialog_action = get_attr(element, "dialog", "accept") == "accept"
     try:
-        beta_dialog = getnode(app_node, "dialog", "Beta Warn")
+        beta_dialog = getnode(app_node, "dialog", tr("Beta Warn"))  # Beta Dialog's name needs to be translated
         if dialog_action:
             button_text = "I want to _proceed." if _is_button_with_dot() else "I want to _proceed"
         else:


### PR DESCRIPTION
Anabot was failing to get through the Beta Dialog in non-English locales due to the dialog's name being localized in Anaconda. I added the translation of this name to fix the issue.