### PR TITLE
Fix base handler for advanced partitioning details

### DIFF
--- a/anabot/runtime/installation/hub/partitioning/advanced/details.py
+++ b/anabot/runtime/installation/hub/partitioning/advanced/details.py
@@ -44,6 +44,7 @@ def base_handler(element, app_node, local_node):
     for child in element.xpathEval("./*"):
         handle_step(child, app_node, local_node)
         if not details_node.visible:
+            details_node = getnode(local_node, "page tab list")
             details_node = getnodes(details_node, "page tab", sensitive=None)[0]
     return True
 


### PR DESCRIPTION
The previous fix of the 'page tab' disappearing in partitioning details (commit 94830798) was incomplete and when the situation to be sanitized by it happened, it couldn't actually get the visible (active) page tab node.