### PR TITLE
Fix loop over dict in raid_name()

### DIFF
--- a/anabot/runtime/installation/hub/partitioning/advanced/common.py
+++ b/anabot/runtime/installation/hub/partitioning/advanced/common.py
@@ -42,7 +42,7 @@ def raid_name(raid_level=None, drop_span=True):
         }
     if drop_span:
         exp = re.compile(r'(.*)<span foreground=\"grey\">(.*)</span>')
-        for level in LEVELS:
+        for level in LEVELS.keys():
             LEVELS[level] = exp.sub(r"\1\2", LEVELS[level])
     if raid_level is not None:
         return LEVELS[raid_level]


### PR DESCRIPTION
The original approch shouldn't actually break anything, but pylint was unhappy about it for a reason:

`anabot/runtime/installation/hub/partitioning/advanced/common.py:46:12: E4702: Iterated dict 'LEVELS' is being modified inside for loop body, iterate through a copy of it instead. (modified-iterating-dict)`

This pylint error was actually discovered as part of work on PR #53; this PR (#52) should likely be merged after 53, so that all of the checks pass.