### PR TITLE
PR checks workflow update

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   centos_stream9:
-    # pylint is not available for centos_stream9, disable for now
-    if: false
     runs-on: ubuntu-latest
     container:
       image: quay.io/centos/centos:stream9

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -9,59 +9,6 @@ permissions:
   contents: read
 
 jobs:
-  centos7:
-    # git >= 2.18 is needed for submodules checkout, disable for now
-    if: false
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/centos/centos:centos7
-      env:
-        PYLINT: pylint-2
-    steps:
-      - name: Enable EPEL and install pylint and dependencies
-        run: |
-          yum install -y epel-release
-          yum install -y python2-pylint libxml2-python git
-
-      - name: Checkout change
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          path: anabot
-
-      - name: Build base test
-        run: |
-          pushd $GITHUB_WORKSPACE/anabot/tests
-          ./run_suite.sh
-          popd
-
-  centos_stream8:
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/centos/centos:stream8
-      env:
-        PYLINT: pylint-3
-    steps:
-      - name: Enable EPEL and install pylint and dependencies
-        run: |
-          dnf install -y 'dnf-command(config-manager)'
-          dnf install -y python3-gobject-base
-          dnf config-manager --set-enabled powertools
-          dnf install -y epel-release epel-next-release
-          dnf install -y python3-pylint python3-libxml2 git
-
-      - name: Checkout change
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          path: anabot
-
-      - name: Build base test
-        run: |
-          pushd $GITHUB_WORKSPACE/anabot/tests
-          ./run_suite.sh
-          popd
-
   centos_stream9:
     # pylint is not available for centos_stream9, disable for now
     if: false

--- a/tests/run_suite.sh
+++ b/tests/run_suite.sh
@@ -23,7 +23,7 @@ ANABOT_DIR=`pwd`
 #DOGTAIL_DIR=`install_dogtail $ANABOT_DIR/dogtail/dogtail-*.tar.gz`
 # pylint's return code is bit-ORed value of statuses. See pylint manpage.
 # 3 means: 1 - fatal message + 2 - error message
-${PYLINT:-pylint} --init-hook="import site; site.addsitedir('./lib/python2.7/site-packages/')" anabot; PYLINT_RETCODE=$?
+${PYLINT:-pylint} --init-hook="import site; site.addsitedir('./lib/python3.9/site-packages/')" anabot; PYLINT_RETCODE=$?
 test $[PYLINT_RETCODE & 3] -ne 0 && SCORE=$[SCORE+1]
 
 #rm -rf -- "$DOGTAIL_DIR"


### PR DESCRIPTION
Remove runs on CentOS7 and CS8 from the PR workflow and enable CS9. It should hopefully work fine on CS9, as I briefly tested locally by running the testing script in a CS9 container.