### PR TITLE
PR workflow fixes

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -21,7 +21,8 @@ jobs:
           dnf install -y 'dnf-command(config-manager)'
           dnf config-manager --set-enabled crb
           dnf install -y epel-release epel-next-release
-          dnf install -y python3-pylint python3-libxml2 git
+          dnf install -y python3-pylint python3-libxml2 git python3-gobject-base \
+            libxklavier
 
       - name: Checkout change
         uses: actions/checkout@v3

--- a/.github/workflows/push_deploy.yaml
+++ b/.github/workflows/push_deploy.yaml
@@ -48,4 +48,4 @@ jobs:
         if: always()
         run: |
           podman kill anabot
-          podman image rm quay.io/centos/centos:stream9
+          podman image rm --force quay.io/centos/centos:stream9


### PR DESCRIPTION
- Add missing dependencies (even though they only relate to `lanabot/runtime/installation/hub/keyboard/layouts.py`, it seems better to add them instead of ignore the import errors in pylint)
- Ensure no containers using the base image are left before removing the image. This should address the current failures of the deployment phase in PR workflow, even though I have no idea how there could still be some leftover containers that are actually using the image.