### PR TITLE
Fix sleep workaround with Xorg

### DIFF
--- a/etc/systemd/system/anabot.service
+++ b/etc/systemd/system/anabot.service
@@ -12,7 +12,7 @@ ConditionArchitecture=!s390x
 # It seems the delay shouldn't be needed with Wayland (and/or with the new version
 # of dogtail). If it turns out it's not the case, we should remove the sleep
 # from here and implement it it launcher.py.
-ExecStartPre=sh -c "ps aux | grep -q gnome-kiosk || sleep 30"
+ExecStartPre=sh -c "which Xorg && sleep 30"
 ExecStart=/opt/python_launcher.sh /opt/launcher.py anaconda_installer
 Environment="ANABOT_MODULES=/opt/anabot-modules"
 Environment="ANABOT_CONF=/opt/anabot.ini"


### PR DESCRIPTION
I didn't realize gnome-kiosk is actually used even with Xorg, so the sleep workaround wouldn't actually apply at all. Grepping for Xorg instead should be bulletproof.