### PR TITLE
Do not exit anabot on Wayland due to no Xorg

### DIFF
--- a/etc/systemd/system/anabot.service
+++ b/etc/systemd/system/anabot.service
@@ -12,7 +12,7 @@ ConditionArchitecture=!s390x
 # It seems the delay shouldn't be needed with Wayland (and/or with the new version
 # of dogtail). If it turns out it's not the case, we should remove the sleep
 # from here and implement it it launcher.py.
-ExecStartPre=sh -c "which Xorg && sleep 30"
+ExecStartPre=sh -c "which Xorg && sleep 30 || true"
 ExecStart=/opt/python_launcher.sh /opt/launcher.py anaconda_installer
 Environment="ANABOT_MODULES=/opt/anabot-modules"
 Environment="ANABOT_CONF=/opt/anabot.ini"


### PR DESCRIPTION
Fix the return code of ExecStartPre, otherwise the anabot service exits:
```
sh[3851]: which: no Xorg in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin)
systemd[1]: anabot.service: Control process exited, code=exited, status=1/FAILURE
systemd[1]: anabot.service: Failed with result 'exit-code'.
systemd[1]: Failed to start anabot.service - Anabot.
```