### PR TITLE
Reboot traceback workaround

### DIFF
--- a/anabot/runtime/installation/configuration/__init__.py
+++ b/anabot/runtime/installation/configuration/__init__.py
@@ -130,13 +130,20 @@ REBOOT_BUTTON_NOT_FOUND = NotFound("\"Reboot\" button", "button_not_found")
 
 @handle_act('/reboot')
 def reboot_handler(element, app_node, local_node):
+    if has_feature_hub_config():
+        reboot_button_params = {
+            "intext": "_Continue",
+            "context": "GUI|Standalone Navigation",
+            "drop_underscore": False
+        }
+    else:
+        reboot_button_params = {
+            "intext": "_Reboot",
+            "context": "GUI|Progress"
+        }
+
     try:
-        if has_feature_hub_config():
-            reboot_button = getnode(local_node, "push button", tr("_Continue", context="GUI|Standalone Navigation", drop_underscore=False), timeout=15)
-        else:
-            reboot_button = getnode(local_node, "push button",
-                                    tr("_Reboot", context="GUI|Progress"),
-                                    timeout=15)
+        reboot_button = getnode(local_node, "push button", tr(**reboot_button_params), timeout=15)
     except NonexistentError:
         return REBOOT_BUTTON_NOT_FOUND
 


### PR DESCRIPTION
Tested in a VM using a modified boot.iso and a slightly modified code making a HTTP request to a server on the host just before the reboot to record that the exception occurred and Anabot reboot was successful. Unfortunately my attempts to create a meaningful Beaker test job doing reinstallations in a loop weren't successful and I didn't want to spend more time trying to find some other way - and I think the code changes are pretty straightforward :-).