### PR TITLE
Add post hook to run restorecon in installed system

### DIFF
--- a/profiles/default/hooks/99-restorecon-post.hook
+++ b/profiles/default/hooks/99-restorecon-post.hook
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+echo "Running restorecon on installed system to ensure post hooks didn't break any contexts."
+restorecon /etc/ld.so.cache
+


### PR DESCRIPTION
so that we can make sure that anything run in post hooks doesn't break the file contexts and result in unexpected AVC denials.